### PR TITLE
Fix support for 2024.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Improve caching introduced in 2.1.3
 
+### Fixed
+
+- Fix support for newer versions, remove support for 2022.1 IDEs
+
 ## [2.1.3] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Fixed
 
-- Fix support for newer versions, remove support for 2022.1 IDEs
+- Fix support for newer versions (2024.1+)
 
 ## [2.1.3] - 2024-02-01
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ pluginGroup = com.github.warningimhack3r.npmupdatedependencies
 pluginName = npm-update-dependencies
 pluginRepositoryUrl = https://github.com/WarningImHack3r/npm-update-dependencies
 # SemVer format -> https://semver.org
-pluginVersion = 2.1.3
+pluginVersion = 3.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 221
+pluginSinceBuild = 222
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2022.1
+platformVersion = 2022.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ pluginGroup = com.github.warningimhack3r.npmupdatedependencies
 pluginName = npm-update-dependencies
 pluginRepositoryUrl = https://github.com/WarningImHack3r/npm-update-dependencies
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.0
+pluginVersion = 2.1.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 222
+pluginSinceBuild = 221
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/MainActionGroup.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/MainActionGroup.kt
@@ -1,18 +1,14 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.actions
 
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.UpdateInBackground
 
-class MainActionGroup : DefaultActionGroup() {
+class MainActionGroup : DefaultActionGroup(), UpdateInBackground {
     override fun update(e: AnActionEvent) {
         val editor = e.getData(CommonDataKeys.EDITOR)
         val file = e.getData(CommonDataKeys.PSI_FILE)
         e.presentation.isEnabledAndVisible = editor != null && file?.name == "package.json"
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/MainActionGroup.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/MainActionGroup.kt
@@ -1,5 +1,6 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -9,5 +10,9 @@ class MainActionGroup : DefaultActionGroup() {
         val editor = e.getData(CommonDataKeys.EDITOR)
         val file = e.getData(CommonDataKeys.PSI_FILE)
         e.presentation.isEnabledAndVisible = editor != null && file?.name == "package.json"
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/RemoveAllDeprecationsAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/RemoveAllDeprecationsAction.kt
@@ -2,13 +2,13 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.deprecation
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.UpdateInBackground
 import com.intellij.openapi.components.service
 
-class RemoveAllDeprecationsAction : AnAction() {
+class RemoveAllDeprecationsAction : AnAction(), UpdateInBackground {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = e.project?.service<NUDState>()?.deprecations?.isNotEmpty() ?: false
     }
@@ -16,9 +16,5 @@ class RemoveAllDeprecationsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.deleteAllDeprecations(file)
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/RemoveAllDeprecationsAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/RemoveAllDeprecationsAction.kt
@@ -2,6 +2,7 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.deprecation
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -15,5 +16,9 @@ class RemoveAllDeprecationsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.deleteAllDeprecations(file)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/ReplaceAllDeprecationsAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/ReplaceAllDeprecationsAction.kt
@@ -2,6 +2,7 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.deprecation
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -15,5 +16,9 @@ class ReplaceAllDeprecationsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.replaceAllDeprecations(file)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/ReplaceAllDeprecationsAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/deprecation/ReplaceAllDeprecationsAction.kt
@@ -2,13 +2,13 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.deprecation
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.UpdateInBackground
 import com.intellij.openapi.components.service
 
-class ReplaceAllDeprecationsAction : AnAction() {
+class ReplaceAllDeprecationsAction : AnAction(), UpdateInBackground {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = e.project?.service<NUDState>()?.deprecations?.isNotEmpty() ?: false
     }
@@ -16,9 +16,5 @@ class ReplaceAllDeprecationsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.replaceAllDeprecations(file)
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/scan/InvalidateCachesAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/scan/InvalidateCachesAction.kt
@@ -1,6 +1,7 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.actions.scan
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
@@ -17,5 +18,9 @@ class InvalidateCachesAction : AnAction() {
         val state = e.project?.service<NUDState>() ?: return
         state.availableUpdates.clear()
         state.deprecations.clear()
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/scan/InvalidateCachesAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/scan/InvalidateCachesAction.kt
@@ -1,12 +1,12 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.actions.scan
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.UpdateInBackground
 import com.intellij.openapi.components.service
 
-class InvalidateCachesAction : AnAction() {
+class InvalidateCachesAction : AnAction(), UpdateInBackground {
     override fun update(e: AnActionEvent) {
         val state = e.project?.service<NUDState>()
         e.presentation.isEnabled = if (state != null) {
@@ -18,9 +18,5 @@ class InvalidateCachesAction : AnAction() {
         val state = e.project?.service<NUDState>() ?: return
         state.availableUpdates.clear()
         state.deprecations.clear()
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllLatestAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllLatestAction.kt
@@ -3,6 +3,7 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.update
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions.Kind
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -16,5 +17,9 @@ class UpdateAllLatestAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.updateAll(file, Kind.LATEST)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllLatestAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllLatestAction.kt
@@ -3,13 +3,13 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.update
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions.Kind
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.UpdateInBackground
 import com.intellij.openapi.components.service
 
-class UpdateAllLatestAction : AnAction() {
+class UpdateAllLatestAction : AnAction(), UpdateInBackground {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = e.project?.service<NUDState>()?.availableUpdates?.isNotEmpty() ?: false
     }
@@ -17,9 +17,5 @@ class UpdateAllLatestAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.updateAll(file, Kind.LATEST)
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
@@ -3,6 +3,7 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.update
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions.Kind
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -20,5 +21,9 @@ class UpdateAllSatisfiesAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.updateAll(file, Kind.SATISFIES)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
@@ -3,7 +3,6 @@ package com.github.warningimhack3r.npmupdatedependencies.ui.actions.update
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions.Kind
 import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -21,9 +20,5 @@ class UpdateAllSatisfiesAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
         ActionsCommon.updateAll(file, Kind.SATISFIES)
-    }
-
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
     }
 }


### PR DESCRIPTION
Fixes #79.

Due to a [breaking change](https://github.com/JetBrains/intellij-community/commit/a45d0161609b0ea036252fcc87c10d1bd186f22e#diff-5c1a2f65788fdd5ecd1522bd7b6190120787016b8c6960602957b4a3b2e22e6dL20-R21) recently introduced in 2024.1, IDEs now throw an error if an `AnAction` doesn't implement `getActionUpdateThread()`.

I didn't get warned about this error despite the [IntelliJ Plugin Verifier](https://github.com/JetBrains/intellij-plugin-verifier) scanning my plugins each time a new IntelliJ version gets released. _Edit: that's because it's a runtime error, not a build-time one!_

~~[Introduced in 2022.2](https://github.com/JetBrains/intellij-community/commit/634e02a6b10d26598e6c17767dd960fbe1a46f9f#diff-143b38ea0bb1ac14a9764da521f93899e1a136df7705216dadfffbfc30b4da9dR181-R189), this method is now mandatory. **As a result, I have to drop support for 2022.1 in order to support the newest versions.**~~

---

**Update:** Thanks to @jansorg, it's even easier to fix the support, _and_ not break support for 2022.1 (most importantly, not to bump the major version)!