### PR TITLE
Versions excluder, internal settings rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Introduce the long-awaited blacklist feature
+  - Allows ignoring specific versions or whole dependencies from being updated
+  - Blacklist entries can be added right from the update annotation
+  - The blacklist can be managed from the settings
+  - Supports multiple version selectors for a granular control
+
 ## [2.1.5] - 2024-04-09
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.warningimhack3r.npmupdatedependencies
 pluginName = npm-update-dependencies
 pluginRepositoryUrl = https://github.com/WarningImHack3r/npm-update-dependencies
 # SemVer format -> https://semver.org
-pluginVersion = 2.1.5
+pluginVersion = 2.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 221

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Deprecation.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Deprecation.kt
@@ -9,8 +9,15 @@ data class Deprecation(
         val version: String
     )
 
-    enum class Action(val text: String) {
-        REPLACE("Replace"),
-        REMOVE("Remove")
+    enum class Action {
+        REPLACE,
+        REMOVE;
+
+        override fun toString(): String {
+            return when (this) {
+                REPLACE -> "Replace"
+                REMOVE -> "Remove"
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Deprecation.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Deprecation.kt
@@ -19,5 +19,12 @@ data class Deprecation(
                 REMOVE -> "Remove"
             }
         }
+
+        companion object {
+            fun orderedActions(placeFirst: Action? = null) = enumValues<Action>().toList().let {
+                if (placeFirst == null) it
+                else listOf(placeFirst) + it.filter { action -> action != placeFirst }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/ScanResult.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/ScanResult.kt
@@ -1,0 +1,6 @@
+package com.github.warningimhack3r.npmupdatedependencies.backend.data
+
+data class ScanResult(
+    val versions: Versions,
+    val affectedByFilters: Collection<String> = emptyList()
+)

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
@@ -4,9 +4,16 @@ data class Versions(
     val latest: String,
     val satisfies: String?
 ) {
-    enum class Kind(val text: String) {
-        LATEST("latest"),
-        SATISFIES("satisfying")
+    enum class Kind {
+        LATEST,
+        SATISFIES;
+
+        override fun toString(): String {
+            return when (this) {
+                LATEST -> "Latest"
+                SATISFIES -> "Satisfying"
+            }
+        }
     }
 
     fun from(kind: Kind): String? = when (kind) {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
@@ -27,7 +27,7 @@ data class Versions(
         Kind.SATISFIES.takeIf { satisfies != null },
         Kind.LATEST
     ).let {
-        if (placeFirst == null || (placeFirst == Kind.SATISFIES && satisfies == null)) it
+        if (placeFirst == null || (placeFirst !in it)) it
         else listOf(placeFirst) + it.filter { kind -> kind != placeFirst }
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
@@ -27,7 +27,7 @@ data class Versions(
         Kind.SATISFIES.takeIf { satisfies != null },
         Kind.LATEST
     ).let {
-        if (placeFirst == null) it
+        if (placeFirst == null || (placeFirst == Kind.SATISFIES && satisfies == null)) it
         else listOf(placeFirst) + it.filter { kind -> kind != placeFirst }
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/data/Versions.kt
@@ -1,8 +1,10 @@
 package com.github.warningimhack3r.npmupdatedependencies.backend.data
 
+import org.semver4j.Semver
+
 data class Versions(
-    val latest: String,
-    val satisfies: String?
+    val latest: Semver,
+    val satisfies: Semver? = null
 ) {
     enum class Kind {
         LATEST,
@@ -16,7 +18,7 @@ data class Versions(
         }
     }
 
-    fun from(kind: Kind): String? = when (kind) {
+    fun from(kind: Kind): Semver? = when (kind) {
         Kind.LATEST -> latest
         Kind.SATISFIES -> satisfies
     }
@@ -29,5 +31,5 @@ data class Versions(
         else listOf(placeFirst) + it.filter { kind -> kind != placeFirst }
     }
 
-    fun isEqualToAny(other: String): Boolean = latest == other || satisfies == other
+    fun isEqualToAny(other: Semver): Boolean = latest == other || satisfies == other
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/NUDState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/NUDState.kt
@@ -1,13 +1,13 @@
 package com.github.warningimhack3r.npmupdatedependencies.backend.engine
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Deprecation
-import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
+import com.github.warningimhack3r.npmupdatedependencies.backend.data.ScanResult
 import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarHelper
 import com.intellij.openapi.components.Service
 
 @Service(Service.Level.PROJECT)
 class NUDState {
-    val availableUpdates = mutableMapOf<String, Versions>()
+    val availableUpdates = mutableMapOf<String, ScanResult>()
     val deprecations = mutableMapOf<String, Deprecation>()
     val packageRegistries = mutableMapOf<String, String>()
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/PackageUpdateChecker.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/PackageUpdateChecker.kt
@@ -74,7 +74,7 @@ class PackageUpdateChecker(private val project: Project) {
             return null
         }
 
-        // Check if the latest version is excluded or doesn't satisfy the comparator
+        // Check if the latest version is excluded, is a beta or doesn't satisfy the comparator
         val filtersAffectingVersions = mutableSetOf<String>()
         if (getVersionExcludingFilter(packageName, newestVersion) != null
             || newestVersion.preRelease.isNotEmpty()

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/extensions/Extensions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/extensions/Extensions.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.*
 fun JsonValue.stringValue(): String = text.replace("\"", "")
 
 // Credit: https://jivimberg.io/blog/2018/05/04/parallel-map-in-kotlin/
-fun <A, B> Iterable<A>.parallelMap(f: suspend (A) -> B) = runBlocking(Dispatchers.Default) {
-    coroutineScope { map { async { f(it) } }.awaitAll() }
+fun <T, R> Iterable<T>.parallelMap(mapper: suspend (T) -> R) = runBlocking(SupervisorJob() + Dispatchers.Default) {
+    coroutineScope { map { async { mapper(it) } }.awaitAll() }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -1,87 +1,36 @@
-@file:Suppress("kotlin:S1128") // Suppress "Unused imports should be removed" for Pair destructuring
 package com.github.warningimhack3r.npmupdatedependencies.settings
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Deprecation
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
+import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarMode
 import com.intellij.ide.DataManager
 import com.intellij.openapi.options.ex.Settings
-import com.intellij.openapi.util.component1
-import com.intellij.openapi.util.component2
 import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.dsl.builder.Cell
-import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.builder.selected
-import com.intellij.util.containers.ContainerUtil.zip
-import java.awt.Component
-import javax.swing.JCheckBox
-import javax.swing.JComboBox
+import com.intellij.ui.dsl.builder.*
 
 class NUDSettingsComponent {
-    var values: MutableMap<String, Any> = NUDSettingsState.instance.mapped.toMutableMap()
-        set(newValues) {
-            field = newValues
-            // Update all components
-            check(componentsList.size == newValues.size) {
-                "The number of components (${componentsList.size}) does not match the number of values (${newValues.size})"
-            }
-            zip(componentsList, newValues.values).forEach { (component, value) ->
-                when (component) {
-                    is JComboBox<*> -> component.selectedIndex = value as Int
-                    is JCheckBox -> component.isSelected = value as Boolean
-                }
-            }
-        }
-
-    private var componentsList = mutableListOf<Component>()
     val panel = panel {
+        val settings = NUDSettingsState()
         group("Annotation Actions") {
             row("Default update type:") {
-                comboBox(
-                    Versions.Kind.values()
-                    .map { version ->
-                        version.text.replaceFirstChar { it.uppercase() }
-                    })
-                    .applyToComponent {
-                        componentsList.add(this)
-                        selectedIndex = values["defaultUpdateType"] as Int
-                        addItemListener {
-                            values["defaultUpdateType"] = selectedIndex
-                        }
-                    }
+                comboBox(enumValues<Versions.Kind>().toList())
+                    .bindItem(settings::defaultUpdateType.toMutableProperty())
             }
             row("Default deprecation action:") {
-                comboBox(Deprecation.Action.values().map { it.text })
-                    .applyToComponent {
-                        componentsList.add(this)
-                        selectedIndex = values["defaultDeprecationAction"] as Int
-                        addItemListener {
-                            values["defaultDeprecationAction"] = selectedIndex
-                        }
-                    }
+                comboBox(enumValues<Deprecation.Action>().toList())
+                    .bindItem(settings::defaultDeprecationAction.toMutableProperty())
             }
         }
         group("Deprecations") {
             row {
                 checkBox("Show deprecation banner")
                     .comment("Show a warning banner when at least one dependency is deprecated.")
-                    .applyToComponent {
-                        componentsList.add(this)
-                        isSelected = values["showDeprecationBanner"] as Boolean
-                        addItemListener {
-                            values["showDeprecationBanner"] = isSelected
-                        }
-                    }
+                    .bindSelected(settings::showDeprecationBanner)
             }
             row {
                 checkBox("Automatically reorder dependencies")
                     .comment("Reorder dependencies after replacing deprecated ones.<br>Useful when a new dependency starts with a different letter than the old one.")
-                    .applyToComponent {
-                        componentsList.add(this)
-                        isSelected = values["autoReorderDependencies"] as Boolean
-                        addItemListener {
-                            values["autoReorderDependencies"] = isSelected
-                        }
-                    }
+                    .bindSelected(settings::autoReorderDependencies)
             }
         }
         group("Status Bar") {
@@ -89,25 +38,13 @@ class NUDSettingsComponent {
             row {
                 statusBarEnabled = checkBox("Show status bar widget")
                     .comment("Show a widget in the status bar that shows the scan status, the number of outdated dependencies, and allows you to open them to update them.")
-                    .applyToComponent {
-                        componentsList.add(this)
-                        isSelected = values["showStatusBarWidget"] as Boolean
-                        addItemListener {
-                            values["showStatusBarWidget"] = isSelected
-                        }
-                    }
+                    .bindSelected(settings::showStatusBarWidget)
             }
             indent {
                 row("Status Bar mode:") {
-                    comboBox(listOf("Full", "Compact"))
+                    comboBox(enumValues<StatusBarMode>().toList())
                         .comment("Compact mode only shows \"U\" for outdated dependencies and \"D\" for deprecated dependencies.")
-                        .applyToComponent {
-                            componentsList.add(this)
-                            selectedIndex = values["statusBarMode"] as Int
-                            addItemListener {
-                                values["statusBarMode"] = selectedIndex
-                            }
-                        }
+                        .bindItem(settings::statusBarMode.toMutableProperty())
                 }.enabledIf(statusBarEnabled.selected)
             }
         }
@@ -115,21 +52,16 @@ class NUDSettingsComponent {
             row {
                 checkBox("Auto-fix on save")
                     .comment("Auto-fix applies the default update type and deprecation action to all dependencies when saving <code>package.json</code>.")
-                    .applyToComponent {
-                        componentsList.add(this)
-                        isSelected = values["autoFixOnSave"] as Boolean
-                        addItemListener {
-                            values["autoFixOnSave"] = isSelected
-                        }
-                    }
+                    .bindSelected(settings::autoFixOnSave)
             }
         }
+
         row {
             label("Plugin's keyboard shortcuts can be changed in keymap settings.")
             link("Go to keymap settings") {
                 DataManager.getInstance().dataContextFromFocusAsync.onSuccess { dataContext ->
-                    val settings = Settings.KEY.getData(dataContext) ?: return@onSuccess
-                    settings.select(settings.find("preferences.keymap"))
+                    val jbSettings = Settings.KEY.getData(dataContext) ?: return@onSuccess
+                    jbSettings.select(jbSettings.find("preferences.keymap"))
                 }
             }
         }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -182,7 +182,7 @@ class NUDSettingsComponent {
                             }.filterValues { values ->
                                 values.isNotEmpty()
                             }
-                        }
+                        }.toMutableMap()
                         ProjectManager.getInstance().openProjects.forEach { project ->
                             // if project's currently open file is package.json, re-analyze it
                             FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -4,11 +4,122 @@ import com.github.warningimhack3r.npmupdatedependencies.backend.data.Deprecation
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
 import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarMode
 import com.intellij.ide.DataManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.options.ex.Settings
+import com.intellij.openapi.ui.DialogBuilder
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.ui.table.TableView
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ListTableModel
+import java.awt.Component
+import javax.swing.JTable
+import javax.swing.table.DefaultTableCellRenderer
 
 class NUDSettingsComponent {
+    private data class ExcludedVersion(
+        var packageName: String,
+        var versions: List<String>
+    )
+
+    private class CellRenderer : DefaultTableCellRenderer.UIResource() {
+        override fun getTableCellRendererComponent(
+            table: JTable?,
+            value: Any?,
+            isSelected: Boolean,
+            hasFocus: Boolean,
+            row: Int,
+            column: Int
+        ): Component {
+            return super.getTableCellRendererComponent(table, value, isSelected, false, row, column)
+        }
+    }
+
+    private fun excludedVersionsPanel(
+        excludedVersions: Map<String, List<String>>,
+        newVersions: (Map<String, List<String>>) -> Unit
+    ): DialogBuilder = DialogBuilder(panel).apply {
+        val model = ListTableModel<ExcludedVersion>(
+            object : ColumnInfo<ExcludedVersion, String>("Package") {
+                override fun getRenderer(item: ExcludedVersion?) = CellRenderer()
+
+                override fun valueOf(item: ExcludedVersion?) = item?.packageName
+
+                override fun setValue(item: ExcludedVersion?, value: String?) {
+                    if (item != null && value != null) item.packageName = value
+                }
+
+                override fun isCellEditable(item: ExcludedVersion?) = item != null
+            },
+            object : ColumnInfo<ExcludedVersion, String>("Excluded Versions") {
+                override fun getRenderer(item: ExcludedVersion?) = CellRenderer()
+
+                override fun valueOf(item: ExcludedVersion?) = item?.versions?.joinToString(",")
+
+                override fun setValue(item: ExcludedVersion?, value: String?) {
+                    if (item != null && value != null) {
+                        item.versions = value.split(",").map { it.trim() }.filter { it.isNotBlank() }
+                    }
+                }
+
+                override fun isCellEditable(item: ExcludedVersion?) = item != null
+            }
+        ).apply {
+            addRows(excludedVersions.map { ExcludedVersion(it.key, it.value) })
+        }
+        val table = TableView(model).apply {
+            visibleRowCount = 8
+            rowSelectionAllowed = false
+            tableHeader.reorderingAllowed = false
+
+            setExpandableItemsEnabled(false)
+        }
+        val content = panel {
+            row {
+                text(
+                    "This table is a list of versions that should be excluded from updates.<br/>The left column is the package name, and the right column is a comma-separated list of version patterns to exclude.<br/>Use <code>*</code> to exclude all versions.<br/><br/>Example: a value of <code>1.2.3, 2.*</code> excludes the versions <code>1.2.3</code>, as well as all versions starting with <code>2</code>.<br/>As such, specifying <code>*</code> effectively excludes all versions of a package."
+                )
+            }
+            row {
+                cell(
+                    ToolbarDecorator.createDecorator(table)
+                        .setAddAction {
+                            model.addRow(ExcludedVersion("", emptyList()))
+                        }
+                        .setRemoveAction {
+                            model.removeRow(table.selectedRow)
+                        }
+                        .disableUpDownActions()
+                        .createPanel()
+                )
+                    .horizontalAlign(HorizontalAlign.FILL)
+            }
+        }
+        setTitle("Excluded Versions")
+        setCenterPanel(content)
+        setPreferredFocusComponent(content)
+        addOkAction()
+        addCancelAction()
+        runInEdt(ModalityState.any()) { // Edit "OK" button text
+            okAction.apply {
+                setText("Save")
+                (this as DialogBuilder.OkActionDescriptor).getAction(dialogWrapper)
+            }
+        }
+        setOkOperation {
+            newVersions(model.items.associate { it.packageName to it.versions })
+            dialogWrapper.close(DialogWrapper.OK_EXIT_CODE)
+        }
+        setCancelOperation {
+            dialogWrapper.close(DialogWrapper.CANCEL_EXIT_CODE)
+        }
+        dialogWrapper.setSize(400, 300) // Width is not really respected
+    }
+
     val panel = panel {
         val settings = NUDSettingsState()
         group("Annotation Actions") {
@@ -53,6 +164,16 @@ class NUDSettingsComponent {
                 checkBox("Auto-fix on save")
                     .comment("Auto-fix applies the default update type and deprecation action to all dependencies when saving <code>package.json</code>.")
                     .bindSelected(settings::autoFixOnSave)
+            }
+        }
+        group("Exclusions") {
+            row {
+                button("Show Excluded Versions") {
+                    excludedVersionsPanel(settings.excludedVersions) { newVersions ->
+                        settings.excludedVersions = newVersions
+                        // TODO: start a new scan
+                    }.showAndGet()
+                }
             }
         }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -175,7 +175,14 @@ class NUDSettingsComponent {
                 button("Show Excluded Versions") {
                     excludedVersionsPanel(settings.excludedVersions) { newVersions ->
                         if (settings.excludedVersions == newVersions) return@excludedVersionsPanel
-                        settings.excludedVersions = newVersions
+                        settings.excludedVersions = newVersions.let {
+                            // Remove duplicates and empty lists
+                            it.mapValues { (_, versions) ->
+                                versions.distinct().filter { version -> version.isNotBlank() }
+                            }.filterValues { values ->
+                                values.isNotEmpty()
+                            }
+                        }
                         ProjectManager.getInstance().openProjects.forEach { project ->
                             // if project's currently open file is package.json, re-analyze it
                             FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -50,7 +50,7 @@ class NUDSettingsComponent {
                 override fun valueOf(item: ExcludedVersion?) = item?.packageName
 
                 override fun setValue(item: ExcludedVersion?, value: String?) {
-                    if (item != null && value != null) item.packageName = value
+                    if (item != null && value != null) item.packageName = value.trim()
                 }
 
                 override fun isCellEditable(item: ExcludedVersion?) = item != null

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsConfigurable.kt
@@ -1,21 +1,17 @@
 package com.github.warningimhack3r.npmupdatedependencies.settings
 
 import com.intellij.openapi.options.Configurable
-import javax.swing.JComponent
 
 class NUDSettingsConfigurable : Configurable {
-    private val settingsView: NUDSettingsComponent by lazy { NUDSettingsComponent() }
-    override fun createComponent(): JComponent = settingsView.panel
+    private val settingsPanel by lazy { NUDSettingsComponent().panel }
 
-    override fun isModified(): Boolean = NUDSettingsState.instance.mapped != settingsView.values
+    override fun createComponent() = settingsPanel
 
-    override fun apply() {
-        NUDSettingsState.instance.mapped = settingsView.values
-    }
+    override fun isModified() = settingsPanel.isModified()
 
-    override fun reset() {
-        settingsView.values = NUDSettingsState.instance.mapped.toMutableMap()
-    }
+    override fun apply() = settingsPanel.apply()
+
+    override fun reset() = settingsPanel.reset()
 
     override fun getDisplayName() = "NPM Update Dependencies"
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -74,9 +74,6 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         var showStatusBarWidget: Boolean = true,
         var statusBarMode: StatusBarMode = StatusBarMode.FULL,
         var autoFixOnSave: Boolean = false,
-        var excludedVersions: Map<String, List<String>> = mapOf(
-            "@sveltejs/kit" to listOf("1.*", "2.5.*"),
-            "paypal-rest-sdk" to listOf("*")
-        )
+        var excludedVersions: Map<String, List<String>> = emptyMap()
     )
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -60,7 +60,7 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         set(value) {
             settings.autoFixOnSave = value
         }
-    var excludedVersions: Map<String, List<String>>
+    var excludedVersions: MutableMap<String, List<String>>
         get() = settings.excludedVersions
         set(value) {
             settings.excludedVersions = value
@@ -74,6 +74,6 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         var showStatusBarWidget: Boolean = true,
         var statusBarMode: StatusBarMode = StatusBarMode.FULL,
         var autoFixOnSave: Boolean = false,
-        var excludedVersions: Map<String, List<String>> = emptyMap()
+        var excludedVersions: MutableMap<String, List<String>> = emptyMap<String, List<String>>().toMutableMap()
     )
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -2,54 +2,71 @@ package com.github.warningimhack3r.npmupdatedependencies.settings
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Deprecation
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
-import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarHelper
+import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarMode
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.util.xmlb.annotations.Transient
 import com.intellij.util.xmlb.XmlSerializerUtil.copyBean
-import java.lang.reflect.Modifier
 
-@State(name = "NUDSettings", storages = [(Storage("npm-update-dependencies.xml"))])
-class NUDSettingsState : PersistentStateComponent<NUDSettingsState> {
+@State(name = "NUDSettings", storages = [Storage("npm-update-dependencies.xml")])
+class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
     companion object {
         val instance: NUDSettingsState
             get() = ApplicationManager.getApplication().getService(NUDSettingsState::class.java)
     }
+    private var settings = Settings()
+
+    override fun getState(): Settings = settings
+
+    override fun loadState(state: Settings) {
+        copyBean(state, settings)
+    }
 
     // Settings
-    var defaultUpdateType: Int = Versions.Kind.SATISFIES.ordinal
-    var defaultDeprecationAction: Int = Deprecation.Action.REPLACE.ordinal
-    var showDeprecationBanner: Boolean = true
-    var autoReorderDependencies: Boolean = true
-    var showStatusBarWidget: Boolean = true
-    var statusBarMode: Int = 0
-    var autoFixOnSave: Boolean = false
-
-    // Map of the settings
-    @get:Transient
-    var mapped = mapOf<String, Any>()
-        get() = javaClass.declaredFields.filter {
-                !Modifier.isStatic(it.modifiers) && it.type != Map::class.java
-            }.associate { f ->
-                f.name to f[this]
-            }
-        set(values) {
-            field = values
-            values.forEach { (key, value) ->
-                javaClass.declaredFields.first { field ->
-                    field.name == key
-                }[this] = value
-                if (key.lowercase().contains("statusbar")) {
-                    StatusBarHelper.updateWidget()
-                }
-            }
+    var defaultUpdateType: Versions.Kind?
+        get() = settings.defaultUpdateType
+        set(value) {
+            if (value != null) settings.defaultUpdateType = value
+        }
+    var defaultDeprecationAction: Deprecation.Action?
+        get() = settings.defaultDeprecationAction
+        set(value) {
+            if (value != null) settings.defaultDeprecationAction = value
+        }
+    var showDeprecationBanner: Boolean
+        get() = settings.showDeprecationBanner
+        set(value) {
+            settings.showDeprecationBanner = value
+        }
+    var autoReorderDependencies: Boolean
+        get() = settings.autoReorderDependencies
+        set(value) {
+            settings.autoReorderDependencies = value
+        }
+    var showStatusBarWidget: Boolean
+        get() = settings.showStatusBarWidget
+        set(value) {
+            settings.showStatusBarWidget = value
+        }
+    var statusBarMode: StatusBarMode?
+        get() = settings.statusBarMode
+        set(value) {
+            if (value != null) settings.statusBarMode = value
+        }
+    var autoFixOnSave: Boolean
+        get() = settings.autoFixOnSave
+        set(value) {
+            settings.autoFixOnSave = value
         }
 
-    override fun getState(): NUDSettingsState = this
-
-    override fun loadState(state: NUDSettingsState) {
-        copyBean(state, this)
-    }
+    data class Settings(
+        var defaultUpdateType: Versions.Kind = Versions.Kind.SATISFIES,
+        var defaultDeprecationAction: Deprecation.Action = Deprecation.Action.REPLACE,
+        var showDeprecationBanner: Boolean = true,
+        var autoReorderDependencies: Boolean = true,
+        var showStatusBarWidget: Boolean = true,
+        var statusBarMode: StatusBarMode = StatusBarMode.FULL,
+        var autoFixOnSave: Boolean = false
+    )
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -15,6 +15,7 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         val instance: NUDSettingsState
             get() = ApplicationManager.getApplication().getService(NUDSettingsState::class.java)
     }
+
     private var settings = Settings()
 
     override fun getState(): Settings = settings
@@ -59,6 +60,11 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         set(value) {
             settings.autoFixOnSave = value
         }
+    var excludedVersions: Map<String, List<String>>
+        get() = settings.excludedVersions
+        set(value) {
+            settings.excludedVersions = value
+        }
 
     data class Settings(
         var defaultUpdateType: Versions.Kind = Versions.Kind.SATISFIES,
@@ -67,6 +73,10 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         var autoReorderDependencies: Boolean = true,
         var showStatusBarWidget: Boolean = true,
         var statusBarMode: StatusBarMode = StatusBarMode.FULL,
-        var autoFixOnSave: Boolean = false
+        var autoFixOnSave: Boolean = false,
+        var excludedVersions: Map<String, List<String>> = mapOf(
+            "@sveltejs/kit" to listOf("1.*", "2.5.*"),
+            "paypal-rest-sdk" to listOf("*")
+        )
     )
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/actions/update/UpdateAllSatisfiesAction.kt
@@ -13,7 +13,7 @@ class UpdateAllSatisfiesAction : AnAction() {
         val availableUpdates = e.project?.service<NUDState>()?.availableUpdates
         e.presentation.isEnabled = if (availableUpdates != null) {
             availableUpdates.isNotEmpty()
-                    && availableUpdates.values.mapNotNull { it.satisfies }.any()
+                    && availableUpdates.values.mapNotNull { it.versions.satisfies }.any()
         } else false
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/DeprecationAnnotator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/DeprecationAnnotator.kt
@@ -114,7 +114,7 @@ class DeprecationAnnotator : DumbAware, ExternalAnnotator<
                 .applyIf(deprecation.replacement != null) {
                     withFix(DeprecatedDependencyFix(property, deprecation.replacement!!.name, deprecation.replacement.version, Deprecation.Action.REPLACE, true))
                 }
-                .withFix(DeprecatedDependencyFix(property, "", "", Deprecation.Action.REMOVE, Deprecation.Action.values().size.run {
+                .withFix(DeprecatedDependencyFix(property, "", "", Deprecation.Action.REMOVE,  enumValues<Deprecation.Action>().size.run {
                     this - (if (deprecation.replacement == null) 1 else 0)
                 } > 1))
                 .needsUpdateOnTyping()

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.util.applyIf
+import org.semver4j.Semver
 
 class UpdatesAnnotator : DumbAware, ExternalAnnotator<
         Pair<Project, List<Property>>,
@@ -58,7 +59,7 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                 val value = property.comparator ?: return@parallelMap null
                 val newVersion = updateChecker.areUpdatesAvailable(property.name, value)
                 state.scannedUpdates++
-                if (newVersion != null && !newVersion.isEqualToAny(value)) Pair(
+                if (newVersion != null && !newVersion.isEqualToAny(Semver(value))) Pair(
                     property.jsonProperty,
                     newVersion
                 ) else null
@@ -79,13 +80,13 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                 .range(property.value!!.textRange)
                 .highlightType(ProblemHighlightType.WARNING)
                 .applyIf(versions.satisfies != null) {
-                    withFix(UpdateDependencyFix(Kind.SATISFIES, property, versions.satisfies!!, true))
+                    withFix(UpdateDependencyFix(Kind.SATISFIES, property, versions.satisfies!!.version, true))
                 }
                 .withFix(
                     UpdateDependencyFix(
                         Kind.LATEST,
                         property,
-                        versions.latest,
+                        versions.latest.version,
                         versions.orderedAvailableKinds().size > 1
                     )
                 )

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
@@ -59,12 +59,12 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                 state.isScanningForUpdates = true
             }.parallelMap { property ->
                 val value = property.comparator ?: return@parallelMap null
-                val newVersion = updateChecker.areUpdatesAvailable(property.name, value)
+                val scanResult = updateChecker.areUpdatesAvailable(property.name, value)
                 state.scannedUpdates++
 
                 val coerced = Semver.coerce(value)
-                if (newVersion != null && coerced != null && !newVersion.versions.isEqualToAny(coerced)) {
-                    Pair(property.jsonProperty, newVersion)
+                if (scanResult != null && coerced != null && !scanResult.versions.isEqualToAny(coerced)) {
+                    Pair(property.jsonProperty, scanResult)
                 } else null
             }.filterNotNull().toMap().also {
                 state.isScanningForUpdates = false
@@ -90,6 +90,7 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                     if (currentVersion == null) return@applyIf this
 
                     val baseIndex = if (versions.satisfies == null) -1 else 0
+                    // Couldn't find a way to create them in a loop here
                     withFix(
                         BlacklistVersionFix(
                             baseIndex + 0, property.name,

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
@@ -63,10 +63,9 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                 state.scannedUpdates++
 
                 val coerced = Semver.coerce(value)
-                if (newVersion != null && coerced != null && !newVersion.versions.isEqualToAny(coerced)) Pair(
-                    property.jsonProperty,
-                    newVersion
-                ) else null
+                if (newVersion != null && coerced != null && !newVersion.versions.isEqualToAny(coerced)) {
+                    Pair(property.jsonProperty, newVersion)
+                } else null
             }.filterNotNull().toMap().also {
                 state.isScanningForUpdates = false
             }
@@ -82,24 +81,14 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
             holder.newAnnotation(HighlightSeverity.WARNING, text)
                 .range(property.value!!.textRange)
                 .highlightType(ProblemHighlightType.WARNING)
-                .withFix(
-                    UpdateDependencyFix(
-                        Kind.LATEST,
-                        property,
-                        versions.latest.version
-                    )
-                )
+                .withFix(UpdateDependencyFix(versions, Kind.LATEST, property))
                 .applyIf(versions.satisfies != null) {
-                    withFix(
-                        UpdateDependencyFix(
-                            Kind.SATISFIES, property,
-                            versions.satisfies!!.version
-                        )
-                    )
+                    withFix(UpdateDependencyFix(versions, Kind.SATISFIES, property))
                 }
                 // Exclude next Major/Minor/Exact/all versions
                 .applyIf(currentVersion != null) {
                     if (currentVersion == null) return@applyIf this
+
                     val baseIndex = if (versions.satisfies == null) -1 else 0
                     withFix(
                         BlacklistVersionFix(

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/annotation/UpdatesAnnotator.kt
@@ -23,9 +23,10 @@ import com.intellij.util.applyIf
 class UpdatesAnnotator : DumbAware, ExternalAnnotator<
         Pair<Project, List<Property>>,
         Map<JsonProperty, Versions>
->() {
+        >() {
 
-    override fun collectInformation(file: PsiFile): Pair<Project, List<Property>> = Pair(file.project, AnnotatorsCommon.getInfo(file))
+    override fun collectInformation(file: PsiFile): Pair<Project, List<Property>> =
+        Pair(file.project, AnnotatorsCommon.getInfo(file))
 
     override fun doAnnotate(collectedInfo: Pair<Project, List<Property>>): Map<JsonProperty, Versions> {
         val (project, info) = collectedInfo
@@ -55,9 +56,9 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
                 state.isScanningForUpdates = true
             }.parallelMap { property ->
                 val value = property.comparator ?: return@parallelMap null
-                val (isUpdateAvailable, newVersion) = updateChecker.hasUpdateAvailable(property.name, value)
+                val newVersion = updateChecker.areUpdatesAvailable(property.name, value)
                 state.scannedUpdates++
-                if (isUpdateAvailable && !newVersion!!.isEqualToAny(value)) Pair(
+                if (newVersion != null && !newVersion.isEqualToAny(value)) Pair(
                     property.jsonProperty,
                     newVersion
                 ) else null
@@ -68,17 +69,28 @@ class UpdatesAnnotator : DumbAware, ExternalAnnotator<
 
     override fun apply(file: PsiFile, annotationResult: Map<JsonProperty, Versions>, holder: AnnotationHolder) {
         annotationResult.forEach { (property, versions) ->
-            holder.newAnnotation(HighlightSeverity.WARNING, "${
-                if (versions.orderedAvailableKinds().size > 1) "${versions.orderedAvailableKinds().size} u" else "U"
+            holder.newAnnotation(
+                HighlightSeverity.WARNING, "${
+                    if (versions.orderedAvailableKinds().size > 1) "${versions.orderedAvailableKinds().size} u" else "U"
                 }pdate${
                     if (versions.orderedAvailableKinds().size > 1) "s" else ""
-                } available")
+                } available"
+            )
                 .range(property.value!!.textRange)
                 .highlightType(ProblemHighlightType.WARNING)
                 .applyIf(versions.satisfies != null) {
                     withFix(UpdateDependencyFix(Kind.SATISFIES, property, versions.satisfies!!, true))
                 }
-                .withFix(UpdateDependencyFix(Kind.LATEST, property, versions.latest, versions.orderedAvailableKinds().size > 1))
+                .withFix(
+                    UpdateDependencyFix(
+                        Kind.LATEST,
+                        property,
+                        versions.latest,
+                        versions.orderedAvailableKinds().size > 1
+                    )
+                )
+                // TODO: Add Exclude Major/Minor/Exact/All versions
+                // TODO: Mention excluded versions in the tooltip if affected
                 .needsUpdateOnTyping()
                 .create()
         }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/banner/DeprecationBanner.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/banner/DeprecationBanner.kt
@@ -31,14 +31,14 @@ class DeprecationBanner : EditorNotificationProvider {
         }
         val deprecationsCount = deprecations.size
         return@Function EditorNotificationPanel(JBColor.YELLOW.darker()).apply {
-            val availableActions = Deprecation.Action.values().filter { action ->
+            val availableActions = enumValues<Deprecation.Action>().filter { action ->
                 (action == Deprecation.Action.REPLACE && deprecations.any { (_, deprecation) ->
                     deprecation.replacement != null
                 }) || action != Deprecation.Action.REPLACE
             }
             // Description text & icon
             val actionsTitles = availableActions.mapIndexed { index, action ->
-                action.text.applyIf(index > 0) {
+                action.toString().applyIf(index > 0) {
                     lowercase()
                 }
             }
@@ -56,11 +56,11 @@ class DeprecationBanner : EditorNotificationProvider {
 
             // Actions
             listOf(availableActions.firstOrNull { action ->
-                action.ordinal == NUDSettingsState.instance.defaultDeprecationAction
+                action == NUDSettingsState.instance.defaultDeprecationAction
             }).plus(availableActions.filter { action ->
-                action.ordinal != NUDSettingsState.instance.defaultDeprecationAction
+                action != NUDSettingsState.instance.defaultDeprecationAction
             }).filterNotNull().forEach { action ->
-                createActionLabel(action.text + if (deprecationsCount > 1) " them" else " it") {
+                createActionLabel(action.toString() + if (deprecationsCount > 1) " them" else " it") {
                     when (action) {
                         Deprecation.Action.REPLACE -> ActionsCommon.replaceAllDeprecations(psiFile)
                         Deprecation.Action.REMOVE -> ActionsCommon.deleteAllDeprecations(psiFile)

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/banner/DeprecationBanner.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/banner/DeprecationBanner.kt
@@ -15,6 +15,7 @@ import com.intellij.ui.EditorNotificationProvider
 import com.intellij.ui.EditorNotifications
 import com.intellij.ui.JBColor
 import com.intellij.util.applyIf
+import com.jetbrains.rd.util.first
 import java.util.function.Function
 import javax.swing.JComponent
 
@@ -47,11 +48,13 @@ class DeprecationBanner : EditorNotificationProvider {
             } else {
                 actionsTitles.first()
             }
-            text(if (deprecationsCount > 1) {
-                "You have $deprecationsCount deprecated packages. $actionsString them"
-            } else {
-                "$deprecationsCount package is deprecated. $actionsString it"
-            } + " to avoid issues.")
+            text(
+                if (deprecationsCount > 1) {
+                    "You have $deprecationsCount deprecated packages. $actionsString them"
+                } else {
+                    "$deprecationsCount package is deprecated. $actionsString it"
+                } + " to avoid issues."
+            )
             icon(AllIcons.General.Warning)
 
             // Actions
@@ -60,7 +63,13 @@ class DeprecationBanner : EditorNotificationProvider {
             }).plus(availableActions.filter { action ->
                 action != NUDSettingsState.instance.defaultDeprecationAction
             }).filterNotNull().forEach { action ->
-                createActionLabel(action.toString() + if (deprecationsCount > 1) " them" else " it") {
+                createActionLabel(
+                    action.toString() + if (deprecationsCount > 1) {
+                        " deprecations"
+                    } else {
+                        " \"${deprecations.first().key}\""
+                    }
+                ) {
                     when (action) {
                         Deprecation.Action.REPLACE -> ActionsCommon.replaceAllDeprecations(psiFile)
                         Deprecation.Action.REMOVE -> ActionsCommon.deleteAllDeprecations(psiFile)

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/ActionsCommon.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/ActionsCommon.kt
@@ -1,7 +1,7 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.helpers
 
-import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
+import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.backend.extensions.stringValue
 import com.github.warningimhack3r.npmupdatedependencies.settings.NUDSettingsState
 import com.intellij.json.psi.JsonProperty
@@ -24,9 +24,9 @@ object ActionsCommon {
     fun updateAll(file: PsiFile, kind: Versions.Kind) {
         getAllDependencies(file)
             .mapNotNull { property ->
-                file.project.service<NUDState>().availableUpdates[property.name]?.let { versions ->
-                    val newVersion = versions.from(kind) ?: versions.orderedAvailableKinds(kind)
-                        .firstOrNull { it != kind }?.let { versions.from(it) } ?: return@mapNotNull null
+                file.project.service<NUDState>().availableUpdates[property.name]?.let { scanResult ->
+                    val newVersion = scanResult.versions.from(kind) ?: scanResult.versions.orderedAvailableKinds(kind)
+                        .firstOrNull { it != kind }?.let { scanResult.versions.from(it) } ?: return@mapNotNull null
                     val prefix = NUDHelper.Regex.semverPrefix.find(property.value?.stringValue() ?: "")?.value ?: ""
                     val newElement = NUDHelper.createElement(property.project, "\"$prefix$newVersion\"", "JSON")
                     Pair(property, newElement)
@@ -50,7 +50,8 @@ object ActionsCommon {
                     val replacement = deprecation.replacement ?: return@mapNotNull null
                     val prefix = NUDHelper.Regex.semverPrefix.find(property.value?.stringValue() ?: "")?.value ?: ""
                     val newNameElement = NUDHelper.createElement(property.project, "\"${replacement.name}\"", "JSON")
-                    val newVersionElement = NUDHelper.createElement(property.project, "\"$prefix${replacement.version}\"", "JSON")
+                    val newVersionElement =
+                        NUDHelper.createElement(property.project, "\"$prefix${replacement.version}\"", "JSON")
                     Triple(property, newNameElement, newVersionElement)
                 }
             }.run {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/QuickFixesCommon.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/QuickFixesCommon.kt
@@ -4,13 +4,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
 
 object QuickFixesCommon {
-    fun getPositionPrefix(enumValue: Enum<*>, setting: Int): String {
-        val position = if (setting == enumValue.ordinal) 1 else {
-            enumValue.javaClass.enumConstants.filter {
-                it.ordinal != setting
-            }.indexOf(enumValue) + 2
-        }
-        return "$position. "
+    fun <T : Enum<*>> getPositionPrefix(enumValue: T, orderedValues: List<T>): String {
+        return "${orderedValues.indexOf(enumValue) + 1}. "
     }
 
     fun getAvailability(editor: Editor?, file: PsiFile?): Boolean {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/listeners/OnSaveListener.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/listeners/OnSaveListener.kt
@@ -33,16 +33,16 @@ class OnSaveListener(val project: Project) : FileDocumentManagerListener {
         // Fix updates if any
         if (state.availableUpdates.isNotEmpty()) {
             actionsToPerform.add {
-                ActionsCommon.updateAll(file, Versions.Kind.values().first {
-                    it.ordinal == NUDSettingsState.instance.defaultUpdateType
+                ActionsCommon.updateAll(file, enumValues<Versions.Kind>().first {
+                    it == NUDSettingsState.instance.defaultUpdateType
                 })
             }
         }
 
         // Fix deprecations if any
         if (state.deprecations.isNotEmpty()) {
-            when (Deprecation.Action.values().first {
-                it.ordinal == NUDSettingsState.instance.defaultDeprecationAction
+            when (enumValues<Deprecation.Action>().first {
+                it == NUDSettingsState.instance.defaultDeprecationAction
             }) {
                 Deprecation.Action.REPLACE -> actionsToPerform.add {
                     ActionsCommon.replaceAllDeprecations(file)

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/BlacklistVersionFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/BlacklistVersionFix.kt
@@ -1,10 +1,12 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.quickfix
 
 import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
+import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.settings.NUDSettingsState
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.QuickFixesCommon
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
@@ -24,6 +26,7 @@ class BlacklistVersionFix(
         QuickFixesCommon.getAvailability(editor, file)
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        // Exclude pattern
         NUDSettingsState.instance.excludedVersions[dependencyName] =
             NUDSettingsState.instance.excludedVersions[dependencyName]
                 ?.plus(versionPattern)?.distinct()
@@ -31,5 +34,7 @@ class BlacklistVersionFix(
         file?.let {
             DaemonCodeAnalyzer.getInstance(project).restart(it)
         }
+        // Clear the cache
+        project.service<NUDState>().availableUpdates.remove(dependencyName)
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/BlacklistVersionFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/BlacklistVersionFix.kt
@@ -1,0 +1,35 @@
+package com.github.warningimhack3r.npmupdatedependencies.ui.quickfix
+
+import com.github.warningimhack3r.npmupdatedependencies.backend.data.Versions
+import com.github.warningimhack3r.npmupdatedependencies.settings.NUDSettingsState
+import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.QuickFixesCommon
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+class BlacklistVersionFix(
+    private val index: Int,
+    private val dependencyName: String,
+    private val versionPattern: String,
+    private val versionName: String? = null
+) : BaseIntentionAction() {
+    override fun getText() =
+        "${enumValues<Versions.Kind>().size + 1 + index}. Blacklist ${versionName ?: versionPattern} for $dependencyName"
+
+    override fun getFamilyName() = "Blacklist version $versionPattern for $dependencyName"
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?) =
+        QuickFixesCommon.getAvailability(editor, file)
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        NUDSettingsState.instance.excludedVersions[dependencyName] =
+            NUDSettingsState.instance.excludedVersions[dependencyName]
+                ?.plus(versionPattern)?.distinct()
+                ?: listOf(versionPattern)
+        file?.let {
+            DaemonCodeAnalyzer.getInstance(project).restart(it)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
@@ -49,9 +49,9 @@ class DeprecatedDependencyFix(
         when (actionType) {
             Deprecation.Action.REPLACE -> {
                 val prefix = NUDHelper.Regex.semverPrefix.find(property.value?.stringValue() ?: "")?.value ?: ""
-                val newName = NUDHelper.createElement(project, "\"${replacementName}\"", "JSON")
-                val newVersion = NUDHelper.createElement(project, "\"$prefix${replacementVersion}\"", "JSON")
-                NUDHelper.safeFileWrite(file, "Replace \"${property.name}\" by \"${replacementName}\"") {
+                val newName = NUDHelper.createElement(project, "\"$replacementName\"", "JSON")
+                val newVersion = NUDHelper.createElement(project, "\"$prefix$replacementVersion\"", "JSON")
+                NUDHelper.safeFileWrite(file, "Replace \"${property.name}\" by \"$replacementName\"") {
                     property.nameElement.replace(newName)
                     property.value?.replace(newVersion)
                 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
@@ -31,7 +31,7 @@ class DeprecatedDependencyFix(
         }
         return (if (showOrder) QuickFixesCommon.getPositionPrefix(
             actionType,
-            NUDSettingsState.instance.defaultDeprecationAction
+            NUDSettingsState.instance.defaultDeprecationAction!!.ordinal
         ) else "") + baseText
     }
     override fun getFamilyName(): String = "Replace or remove deprecated dependency"
@@ -40,7 +40,7 @@ class DeprecatedDependencyFix(
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         if (file == null) {
-            printlnError("Trying to ${actionType.text.lowercase()} dependency but the file is null")
+            printlnError("Trying to ${actionType.toString().lowercase()} dependency but the file is null")
             return
         }
         when (actionType) {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
@@ -19,10 +19,10 @@ class UpdateDependencyFix(
     private val showOrder: Boolean
 ): BaseIntentionAction() {
     override fun getText(): String {
-        val baseText = "Update to ${kind.text} version ($newVersion)"
+        val baseText = "Update to $kind version ($newVersion)"
         return (if (showOrder) QuickFixesCommon.getPositionPrefix(
             kind,
-            NUDSettingsState.instance.defaultUpdateType
+            NUDSettingsState.instance.defaultUpdateType!!.ordinal
         ) else "") + baseText
     }
     override fun getFamilyName() = "Update dependency"

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
@@ -15,15 +15,13 @@ import com.jetbrains.rd.util.printlnError
 class UpdateDependencyFix(
     private val kind: Versions.Kind,
     private val property: JsonProperty,
-    private val newVersion: String,
-    private val showOrder: Boolean
+    private val newVersion: String
 ) : BaseIntentionAction() {
     override fun getText(): String {
-        val baseText = "Update to ${kind.toString().lowercase()} version ($newVersion)"
-        return (if (showOrder) QuickFixesCommon.getPositionPrefix(
+        return QuickFixesCommon.getPositionPrefix(
             kind,
             NUDSettingsState.instance.defaultUpdateType!!.ordinal
-        ) else "") + baseText
+        ) + "Update to ${kind.toString().lowercase()} version ($newVersion)"
     }
 
     override fun getFamilyName() = "Update dependency"

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
@@ -13,16 +13,16 @@ import com.intellij.psi.PsiFile
 import com.jetbrains.rd.util.printlnError
 
 class UpdateDependencyFix(
+    private val versions: Versions,
     private val kind: Versions.Kind,
-    private val property: JsonProperty,
-    private val newVersion: String
+    private val property: JsonProperty
 ) : BaseIntentionAction() {
-    override fun getText(): String {
-        return QuickFixesCommon.getPositionPrefix(
-            kind,
-            NUDSettingsState.instance.defaultUpdateType!!.ordinal
-        ) + "Update to ${kind.toString().lowercase()} version ($newVersion)"
-    }
+    val version = versions.from(kind)
+
+    override fun getText() = QuickFixesCommon.getPositionPrefix(
+        kind,
+        versions.orderedAvailableKinds(NUDSettingsState.instance.defaultUpdateType!!)
+    ) + "Update to ${kind.toString().lowercase()} version ($version)"
 
     override fun getFamilyName() = "Update dependency"
 
@@ -35,8 +35,8 @@ class UpdateDependencyFix(
             return
         }
         val prefix = NUDHelper.Regex.semverPrefix.find(property.value?.stringValue() ?: "")?.value ?: ""
-        val newElement = NUDHelper.createElement(project, "\"$prefix$newVersion\"", "JSON")
-        NUDHelper.safeFileWrite(file, "Update \"${property.name}\" to $newVersion") {
+        val newElement = NUDHelper.createElement(project, "\"$prefix$version\"", "JSON")
+        NUDHelper.safeFileWrite(file, "Update \"${property.name}\" to $version") {
             property.value?.replace(newElement)
         }
     }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/UpdateDependencyFix.kt
@@ -17,17 +17,19 @@ class UpdateDependencyFix(
     private val property: JsonProperty,
     private val newVersion: String,
     private val showOrder: Boolean
-): BaseIntentionAction() {
+) : BaseIntentionAction() {
     override fun getText(): String {
-        val baseText = "Update to $kind version ($newVersion)"
+        val baseText = "Update to ${kind.toString().lowercase()} version ($newVersion)"
         return (if (showOrder) QuickFixesCommon.getPositionPrefix(
             kind,
             NUDSettingsState.instance.defaultUpdateType!!.ordinal
         ) else "") + baseText
     }
+
     override fun getFamilyName() = "Update dependency"
 
-    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = QuickFixesCommon.getAvailability(editor, file)
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean =
+        QuickFixesCommon.getAvailability(editor, file)
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         if (file == null) {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/statusbar/StatusBarFactory.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/statusbar/StatusBarFactory.kt
@@ -33,6 +33,17 @@ class StatusBarFactory : StatusBarEditorBasedWidgetFactory() {
     override fun disposeWidget(widget: StatusBarWidget) = Disposer.dispose(widget)
 }
 
+enum class StatusBarMode {
+    FULL, COMPACT;
+
+    override fun toString(): String {
+        return when (this) {
+            FULL -> "Full"
+            COMPACT -> "Compact"
+        }
+    }
+}
+
 class WidgetBar(project: Project) : EditorBasedWidget(project), StatusBarWidget.MultipleTextValuesPresentation {
     companion object {
         const val ID = "NpmUpdateDependenciesStatusBarWidgetBar"
@@ -143,21 +154,19 @@ class WidgetBar(project: Project) : EditorBasedWidget(project), StatusBarWidget.
                 val outdated = state.availableUpdates.size
                 val deprecated = state.deprecations.size
                 when (NUDSettingsState.instance.statusBarMode) {
-                    // Full
-                    0 -> when {
+                    StatusBarMode.FULL -> when {
                         outdated == 0 && deprecated == 0 -> null
                         outdated == 0 -> "$deprecated deprecation${if (deprecated == 1) "" else "s"}"
                         deprecated == 0 -> "$outdated update${if (outdated == 1) "" else "s"}"
                         else -> "$outdated update${if (outdated == 1) "" else "s"}, $deprecated deprecation${if (deprecated == 1) "" else "s"}"
                     }
-                    // Compact
-                    1 -> when {
+                    StatusBarMode.COMPACT -> when {
                         outdated == 0 && deprecated == 0 -> null
                         outdated == 0 -> "$deprecated D"
                         deprecated == 0 -> "$outdated U"
                         else -> "$outdated U / $deprecated D"
                     }
-                    else -> null
+                    null -> null
                 }
             }
         }


### PR DESCRIPTION
Fixes #85.

As described in https://github.com/WarningImHack3r/npm-update-dependencies/issues/85#issue-2204529046 and [this review](https://plugins.jetbrains.com/plugin/21105-npm-update-dependencies/reviews#review=98051), sometimes it's good to decide whether or not we want to skip/exclude an update due to some bugs from that version or some other reason.

For that reason, add a mechanism that unlocks deeper customization, allowing to exclude some versions (patterns) from being flagged as available versions to upgrade to. In short, a version blacklist.

## Technical changes
- Add a persistent structure that maps package names to some of their versions to exclude from checks
- Take it into account within the update checker mechanism
- Adjust the annotators and available quick fixes accordingly
- Add a setting to review and edit excluded versions manually

## Additional "side-effect" changes
- Rethink the settings' internal persistence structure for a simpler design and more modern practices
- Change the main "Update available" fixup alert text
- Improve error handling for parallel tasks
- Adjust deprecation banner-related texts

## TODO list (unordered)
- [x] Trigger a new scan after manual update
- [x] Improve fallback version fetching
- [x] Add a quick fix to exclude a version, all versions, the major or the minor of a package
- [x] Mention if quick fixes are affected by excluded versions if so, display the filter(s) that do