### PR TITLE
Add support for unmaintained packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add warnings for unmaintained dependencies (#140)
+  - Dependencies are considered likely unmaintained if they have not been updated for a long time, **configurable in the settings**
+
 ## [3.2.1] - 2024-09-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Add warnings for unmaintained dependencies (#140)
   - Dependencies are considered likely unmaintained if they have not been updated for a long time, **configurable in the settings**
 
+### Fixed
+
+- Fix inaccurate cache invalidation when tweaking excluded packages setting
+
 ## [3.2.1] - 2024-09-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ version depending on your choice.
 - Keep comparators (e.g. `^`, `~`, `>`, `<`, `>=`, `<=`) when replacing versions
 - Get notified of deprecated dependencies with a banner
 - Detect and replace/remove deprecated dependencies
+- Configure and spot dependencies that are likely unmaintained
 - Batch update all dependencies (latest or satisfying) and/or all deprecated dependencies
 - Support for custom registries and private packages
 - Support of the `packageManager` field

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/NPMJSClient.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/NPMJSClient.kt
@@ -188,4 +188,21 @@ class NPMJSClient(private val project: Project) {
             }
         }
     }
+
+    fun getPackageLastModified(packageName: String): String? {
+        log.info("Getting last modified date for package $packageName")
+        val registry = getRegistry(packageName)
+        val json = getBodyAsJSON("${registry}/$packageName")
+        return json?.get("time")?.asJsonObject?.get("modified")?.asString?.also {
+            log.info("Last modified date for package $packageName found online: $it")
+        } ?: ShellRunner.getInstance(project).execute(
+            arrayOf("npm", "v", packageName, "time.modified", "--registry=$registry")
+        )?.trim()?.let { it.ifEmpty { null } }.also {
+            if (it != null) {
+                log.info("Last modified date for package $packageName found locally: $it")
+            } else {
+                log.warn("Last modified date for package $packageName not found")
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
@@ -68,7 +68,9 @@ class PackageDeprecationChecker(private val project: Project) : PackageChecker()
                 return null
             }
             log.debug("No deprecation found for $packageName, checking if it's unmaintained")
-            val lastUpdate = npmjsClient.getPackageLastModified(packageName) ?: return null
+            val lastUpdate = npmjsClient.getPackageLastModified(packageName) ?: return null.also {
+                log.warn("Couldn't get last modification date for $packageName")
+            }
             val lastUpdateInstant = Instant.parse(lastUpdate)
             if (now > lastUpdateInstant + NUDSettingsState.instance.unmaintainedDays.days) {
                 log.debug("Package $packageName is unmaintained")
@@ -80,6 +82,7 @@ class PackageDeprecationChecker(private val project: Project) : PackageChecker()
                     null
                 )
             }
+            log.debug("Package $packageName is maintained")
             return null
         }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
@@ -63,6 +63,10 @@ class PackageDeprecationChecker(private val project: Project) : PackageChecker()
                 log.debug("No deprecation found for $packageName, but it's excluded from unmaintained check")
                 return null
             }
+            if (NUDSettingsState.instance.unmaintainedDays == 0) {
+                log.debug("No deprecation found for $packageName, unmaintained check is disabled")
+                return null
+            }
             log.debug("No deprecation found for $packageName, checking if it's unmaintained")
             val lastUpdate = npmjsClient.getPackageLastModified(packageName) ?: return null
             val lastUpdateInstant = Instant.parse(lastUpdate)

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/engine/checkers/PackageDeprecationChecker.kt
@@ -58,8 +58,10 @@ class PackageDeprecationChecker(private val project: Project) : PackageChecker()
         // Check if the package is deprecated
         val npmjsClient = NPMJSClient.getInstance(project)
         val reason = npmjsClient.getPackageDeprecation(packageName) ?: run {
-            if (NUDSettingsState.instance.excludedUnmaintainedPackages.split(",").map { it.trim() }
-                    .contains(packageName)) {
+            if (NUDSettingsState.instance.excludedUnmaintainedPackages
+                    .split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                    .contains(packageName)
+            ) {
                 log.debug("No deprecation found for $packageName, but it's excluded from unmaintained check")
                 return null
             }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/extensions/Extensions.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/extensions/Extensions.kt
@@ -2,6 +2,7 @@ package com.github.warningimhack3r.npmupdatedependencies.backend.extensions
 
 import com.intellij.json.psi.JsonValue
 import kotlinx.coroutines.*
+import kotlinx.datetime.DateTimePeriod
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
@@ -32,4 +33,16 @@ fun JsonValue.stringValue(): String = text.replace("\"", "")
 // Credit: https://jivimberg.io/blog/2018/05/04/parallel-map-in-kotlin/
 fun <T, R> Iterable<T>.parallelMap(mapper: suspend (T) -> R) = runBlocking(SupervisorJob() + Dispatchers.Default) {
     coroutineScope { map { async { mapper(it) } }.awaitAll() }
+}
+
+fun DateTimePeriod.toReadableString() = buildString {
+    if (years > 0) append("$years year${if (years > 1) "s" else ""}")
+    if (months > 0) {
+        if (years > 0) append(", ")
+        append("$months month${if (months > 1) "s" else ""}")
+    }
+    if (days > 0) {
+        if (years > 0 || months > 0) append(" and ")
+        append("$days day${if (days > 1) "s" else ""}")
+    }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/models/Deprecation.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/backend/models/Deprecation.kt
@@ -1,9 +1,22 @@
 package com.github.warningimhack3r.npmupdatedependencies.backend.models
 
 data class Deprecation(
+    val kind: Kind,
     val reason: String,
     val replacement: Replacement?
 ) {
+    enum class Kind {
+        DEPRECATED,
+        UNMAINTAINED;
+
+        override fun toString(): String {
+            return when (this) {
+                DEPRECATED -> "Deprecated"
+                UNMAINTAINED -> "Unmaintained"
+            }
+        }
+    }
+
     data class Replacement(
         val name: String,
         val version: String
@@ -11,12 +24,14 @@ data class Deprecation(
 
     enum class Action {
         REPLACE,
-        REMOVE;
+        REMOVE,
+        IGNORE;
 
         override fun toString(): String {
             return when (this) {
                 REPLACE -> "Replace"
                 REMOVE -> "Remove"
+                IGNORE -> "Ignore"
             }
         }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsComponent.kt
@@ -1,20 +1,15 @@
 package com.github.warningimhack3r.npmupdatedependencies.settings
 
-import com.github.warningimhack3r.npmupdatedependencies.backend.engine.NUDState
 import com.github.warningimhack3r.npmupdatedependencies.backend.models.Deprecation
 import com.github.warningimhack3r.npmupdatedependencies.backend.models.Versions
 import com.github.warningimhack3r.npmupdatedependencies.ui.statusbar.StatusBarMode
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.ide.DataManager
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.options.ex.Settings
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.ui.DialogBuilder
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
@@ -160,8 +155,8 @@ class NUDSettingsComponent {
                 spinner(0..365 * 10)
                     .comment(
                         """
-                        Control how many days a package can go without an update before it's considered \"likely unmaintained\". Set to 0 to disable.<br>
-                        <em>Keep in mind that a package might still be maintained even if it hasn't been updated in a while. You can adjust this value to your preference, or even exclude specific packages from this check if you consider them to be false positives.</em>
+                        Control how many days a package can go without an update before it's considered "likely unmaintained". Set to 0 to disable.<br>
+                        <em>A package might still be maintained even if it hasn't been updated in a while. You can adjust this value to your liking, or even exclude packages from this check if you know they're still maintained.</em>
                         """.trimIndent()
                     )
                     .bindIntValue(settings::unmaintainedDays)
@@ -222,20 +217,6 @@ class NUDSettingsComponent {
                                 values.isNotEmpty()
                             }
                         }.toMutableMap()
-                        ProjectManager.getInstance().openProjects.forEach { project ->
-                            // Clear the cache for packages with excluded versions
-                            settings.excludedVersions.keys.forEach { packageName ->
-                                NUDState.getInstance(project).availableUpdates.remove(packageName)
-                            }
-                            // if project's currently open file is package.json, re-analyze it
-                            FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->
-                                PsiDocumentManager.getInstance(project).getPsiFile(editor.document)?.let { file ->
-                                    if (file.name == "package.json") {
-                                        DaemonCodeAnalyzer.getInstance(project).restart(file)
-                                    }
-                                }
-                            }
-                        }
                     }.showAndGet()
                 }
             }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -40,10 +40,20 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         set(value) {
             settings.showDeprecationBanner = value
         }
+    var bannerIncludesUnmaintained: Boolean
+        get() = settings.bannerIncludesUnmaintained
+        set(value) {
+            settings.bannerIncludesUnmaintained = value
+        }
     var autoReorderDependencies: Boolean
         get() = settings.autoReorderDependencies
         set(value) {
             settings.autoReorderDependencies = value
+        }
+    var unmaintainedDays: Int
+        get() = settings.unmaintainedDays
+        set(value) {
+            settings.unmaintainedDays = value
         }
     var maxParallelism: Int
         get() = settings.maxParallelism
@@ -75,17 +85,25 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
         set(value) {
             settings.excludedVersions = value
         }
+    var excludedUnmaintainedPackages: String
+        get() = settings.excludedUnmaintainedPackages.joinToString(",")
+        set(value) {
+            settings.excludedUnmaintainedPackages = value.split(",").map { it.trim() }
+        }
 
     data class Settings(
         var defaultUpdateType: Versions.Kind = Versions.Kind.SATISFIES,
         var defaultDeprecationAction: Deprecation.Action = Deprecation.Action.REPLACE,
         var showDeprecationBanner: Boolean = true,
+        var bannerIncludesUnmaintained: Boolean = true,
         var autoReorderDependencies: Boolean = true,
+        var unmaintainedDays: Int = 365,
         var maxParallelism: Int = 100,
         var cacheDurationMinutes: Int = 30,
         var showStatusBarWidget: Boolean = true,
         var statusBarMode: StatusBarMode = StatusBarMode.FULL,
         var autoFixOnSave: Boolean = false,
-        var excludedVersions: MutableMap<String, List<String>> = emptyMap<String, List<String>>().toMutableMap()
+        var excludedVersions: MutableMap<String, List<String>> = emptyMap<String, List<String>>().toMutableMap(),
+        var excludedUnmaintainedPackages: List<String> = listOf()
     )
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/settings/NUDSettingsState.kt
@@ -88,7 +88,7 @@ class NUDSettingsState : PersistentStateComponent<NUDSettingsState.Settings> {
     var excludedUnmaintainedPackages: String
         get() = settings.excludedUnmaintainedPackages.joinToString(",")
         set(value) {
-            settings.excludedUnmaintainedPackages = value.split(",").map { it.trim() }
+            settings.excludedUnmaintainedPackages = value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
         }
 
     data class Settings(

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/ActionsCommon.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/ActionsCommon.kt
@@ -117,12 +117,12 @@ object ActionsCommon {
         }
     }
 
-    fun deleteAllDeprecations(file: PsiFile) {
+    fun deleteAllDeprecations(file: PsiFile, predicate: (JsonProperty) -> Boolean = { true }) {
         val deprecations = NUDState.getInstance(file.project).deprecations
         val deprecationsToRemove = deprecations.filter { it.value.data != null }
         getAllDependencies(file)
-            .mapNotNull { property ->
-                if (deprecationsToRemove.containsKey(property.name)) property else null
+            .filter { property ->
+                deprecationsToRemove.containsKey(property.name) && predicate(property)
             }.run {
                 if (isNotEmpty()) {
                     NUDHelper.safeFileWrite(file, "Delete all deprecations", false) {

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/NUDHelper.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/helpers/NUDHelper.kt
@@ -1,9 +1,12 @@
 package com.github.warningimhack3r.npmupdatedependencies.ui.helpers
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.lang.Language
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
@@ -54,5 +57,15 @@ object NUDHelper {
             sibling = sibling.prevSibling
         }
         return null
+    }
+
+    fun reanalyzePackageJsonIfOpen(project: Project) {
+        FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->
+            PsiDocumentManager.getInstance(project).getPsiFile(editor.document)?.let { file ->
+                if (file.name == "package.json") {
+                    DaemonCodeAnalyzer.getInstance(project).restart(file)
+                }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/listeners/OnSaveListener.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/listeners/OnSaveListener.kt
@@ -53,6 +53,10 @@ class OnSaveListener(val project: Project) : FileDocumentManagerListener {
                 Deprecation.Action.REMOVE -> actionsToPerform.add {
                     ActionsCommon.deleteAllDeprecations(file)
                 }
+
+                Deprecation.Action.IGNORE -> {
+                    // Do nothing, not selectable
+                }
             }
         }
 

--- a/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/npmupdatedependencies/ui/quickfix/DeprecatedDependencyFix.kt
@@ -7,6 +7,7 @@ import com.github.warningimhack3r.npmupdatedependencies.settings.NUDSettingsStat
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.ActionsCommon
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.NUDHelper
 import com.github.warningimhack3r.npmupdatedependencies.ui.helpers.QuickFixesCommon
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.json.psi.JsonProperty
 import com.intellij.openapi.diagnostic.logger
@@ -29,6 +30,7 @@ class DeprecatedDependencyFix(
         val baseText = when (actionType) {
             Deprecation.Action.REPLACE -> "Replace by \"${replacementName}\" (${replacementVersion})"
             Deprecation.Action.REMOVE -> "Remove dependency"
+            Deprecation.Action.IGNORE -> "Ignore deprecation"
         }
         return (if (showOrder) QuickFixesCommon.getPositionPrefix(
             actionType,
@@ -71,6 +73,11 @@ class DeprecatedDependencyFix(
                 }?.delete()
                 // Delete the property
                 property.delete()
+            }
+
+            Deprecation.Action.IGNORE -> {
+                NUDSettingsState.instance.excludedUnmaintainedPackages += ",${property.name}"
+                DaemonCodeAnalyzer.getInstance(project).restart(file)
             }
         }
         NUDState.getInstance(project).deprecations.remove(property.name)


### PR DESCRIPTION
Fixes #140.

### What does it do?

It simply annotates packages that haven't been updated over a configurable amount of time (1 year by default). You can either remove them or ignore them from the "unmaintained" packages list.

### How does it do it?

It extends the existing `DeprecationAnnotator` with an additional kind of `Deprecation`. It fits perfectly the existing codebase, naturally using the cache mechanisms and other integrations.
"Unmaintained" state is fetched from `<registry-url-origin>/<package>`, in the `time.modified` key.

> I coded it quickly this evening, but it should do the trick. It mainly needs more testing, as I haven't even run some features yet.